### PR TITLE
Update for spdm_version removing bit flags.

### DIFF
--- a/spdm_dump/spdm/spdm_dump_secured_spdm.c
+++ b/spdm_dump/spdm/spdm_dump_secured_spdm.c
@@ -26,10 +26,10 @@ void dump_spdm_opaque_version_selection(IN void *buffer, IN uintn buffer_size)
     printf("VERSION_SELECTION ");
 
     printf("(%d.%d.%d.%d) ",
-           version_selection->selected_version.major_version,
-           version_selection->selected_version.minor_version,
-           version_selection->selected_version.update_version_number,
-           version_selection->selected_version.alpha);
+           (version_selection->selected_version >> 12) & 0xF,
+           (version_selection->selected_version >> 8) & 0xF,
+           (version_selection->selected_version >> 4) & 0xF,
+           version_selection->selected_version & 0xF);
 }
 
 void dump_spdm_opaque_supported_version(IN void *buffer, IN uintn buffer_size)
@@ -59,10 +59,11 @@ void dump_spdm_opaque_supported_version(IN void *buffer, IN uintn buffer_size)
         if (index != 0) {
             printf(", ");
         }
-        printf("%d.%d.%d.%d", spdm_version_number[index].major_version,
-               spdm_version_number[index].minor_version,
-               spdm_version_number[index].update_version_number,
-               spdm_version_number[index].alpha);
+        printf("%d.%d.%d.%d",
+               (spdm_version_number[index] >> 12) & 0xF,
+               (spdm_version_number[index] >> 8) & 0xF,
+               (spdm_version_number[index] >> 4) & 0xF,
+               spdm_version_number[index] & 0xF);
         printf(") ");
     }
 }

--- a/spdm_dump/spdm/spdm_dump_spdm.c
+++ b/spdm_dump/spdm/spdm_dump_spdm.c
@@ -307,10 +307,10 @@ void dump_spdm_version(IN void *buffer, IN uintn buffer_size)
                 printf(", ");
             }
             printf("%d.%d.%d.%d",
-                   spdm_version_number[index].major_version,
-                   spdm_version_number[index].minor_version,
-                   spdm_version_number[index].update_version_number,
-                   spdm_version_number[index].alpha);
+                   (spdm_version_number[index] >> 12) & 0xF,
+                   (spdm_version_number[index] >> 8) & 0xF,
+                   (spdm_version_number[index] >> 4) & 0xF,
+                   spdm_version_number[index] & 0xF);
         }
         printf(") ");
     }

--- a/spdm_dump/spdm/spdm_dump_spdm.c
+++ b/spdm_dump/spdm/spdm_dump_spdm.c
@@ -1161,12 +1161,12 @@ void dump_spdm_measurements_record(IN uint8_t number_of_blocks,
             end_of_record) {
             break;
         }
-        if (dmtf_block->Measurement_block_common_header
+        if (dmtf_block->measurement_block_common_header
                 .measurement_specification !=
             SPDM_MEASUREMENT_BLOCK_HEADER_SPECIFICATION_DMTF) {
             break;
         }
-        if (dmtf_block->Measurement_block_common_header
+        if (dmtf_block->measurement_block_common_header
                 .measurement_size !=
             dmtf_block->Measurement_block_dmtf_header
                     .dmtf_spec_measurement_value_size +
@@ -1174,7 +1174,7 @@ void dump_spdm_measurements_record(IN uint8_t number_of_blocks,
             break;
         }
         end_of_block = (uintn)dmtf_block +
-                   dmtf_block->Measurement_block_common_header
+                   dmtf_block->measurement_block_common_header
                        .measurement_size +
                    sizeof(spdm_measurement_block_common_header_t);
         if (end_of_block > end_of_record) {
@@ -1183,16 +1183,16 @@ void dump_spdm_measurements_record(IN uint8_t number_of_blocks,
 
         printf("\n      MeasurementRecord_%d(", (uint32_t)index);
         printf("\n        CommonHeader(Index=0x%02x, MeasSpec=0x%02x(",
-               dmtf_block->Measurement_block_common_header.index,
-               dmtf_block->Measurement_block_common_header
+               dmtf_block->measurement_block_common_header.index,
+               dmtf_block->measurement_block_common_header
                    .measurement_specification);
         dump_entry_flags(
             m_spdm_measurement_spec_value_string_table,
             ARRAY_SIZE(m_spdm_measurement_spec_value_string_table),
-            dmtf_block->Measurement_block_common_header
+            dmtf_block->measurement_block_common_header
                 .measurement_specification);
         printf("), size=0x%04x)",
-               dmtf_block->Measurement_block_common_header
+               dmtf_block->measurement_block_common_header
                    .measurement_size);
 
         printf("\n        DmtfHeader(Type=0x%02x(",

--- a/spdm_dump/spdm/spdm_dump_spdm.c
+++ b/spdm_dump/spdm/spdm_dump_spdm.c
@@ -1099,7 +1099,7 @@ void dump_spdm_get_measurements(IN void *buffer, IN uintn buffer_size)
             message_size = sizeof(spdm_get_measurements_request_t);
         } else {
             message_size = OFFSET_OF(
-                spdm_get_measurements_request_t, SlotIDParam);
+                spdm_get_measurements_request_t, slot_id_param);
         }
     }
     if (buffer_size < message_size) {
@@ -1128,7 +1128,7 @@ void dump_spdm_get_measurements(IN void *buffer, IN uintn buffer_size)
         }
         if (include_signature && (spdm_request->header.spdm_version >=
                       SPDM_MESSAGE_VERSION_11)) {
-            printf(", SlotID=0x%02x", spdm_request->SlotIDParam);
+            printf(", SlotID=0x%02x", spdm_request->slot_id_param);
         }
         printf(") ");
 

--- a/spdm_dump/spdm/spdm_dump_spdm.c
+++ b/spdm_dump/spdm/spdm_dump_spdm.c
@@ -1168,7 +1168,7 @@ void dump_spdm_measurements_record(IN uint8_t number_of_blocks,
         }
         if (dmtf_block->measurement_block_common_header
                 .measurement_size !=
-            dmtf_block->Measurement_block_dmtf_header
+            dmtf_block->measurement_block_dmtf_header
                     .dmtf_spec_measurement_value_size +
                 sizeof(spdm_measurement_block_dmtf_header_t)) {
             break;
@@ -1196,26 +1196,26 @@ void dump_spdm_measurements_record(IN uint8_t number_of_blocks,
                    .measurement_size);
 
         printf("\n        DmtfHeader(Type=0x%02x(",
-               dmtf_block->Measurement_block_dmtf_header
+               dmtf_block->measurement_block_dmtf_header
                    .dmtf_spec_measurement_value_type);
         dump_entry_value(
             m_spdm_measurement_type_value_string_table,
             ARRAY_SIZE(m_spdm_measurement_type_value_string_table),
-            dmtf_block->Measurement_block_dmtf_header
+            dmtf_block->measurement_block_dmtf_header
                     .dmtf_spec_measurement_value_type &
                 SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_MASK);
-        if (dmtf_block->Measurement_block_dmtf_header
+        if (dmtf_block->measurement_block_dmtf_header
                 .dmtf_spec_measurement_value_type &
             SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_RAW_BIT_STREAM) {
             printf(", RawBitStream");
         }
         printf("), Size=0x%04x)",
-               dmtf_block->Measurement_block_dmtf_header
+               dmtf_block->measurement_block_dmtf_header
                    .dmtf_spec_measurement_value_size);
 
         printf("\n        Value(");
         dump_data((void *)(dmtf_block + 1),
-              dmtf_block->Measurement_block_dmtf_header
+              dmtf_block->measurement_block_dmtf_header
                   .dmtf_spec_measurement_value_size);
         printf(")");
         printf("\n        )");


### PR DESCRIPTION
This PR removes bit flags definition in spdm.h.

PR for libspdm - DMTF/libspdm#474