### PR TITLE
Fix Dynamic memory stored in 'm_requester_cert_chain_buffer' can be l…

### DIFF
--- a/spdm_dump/spdm/spdm_dump_session.c
+++ b/spdm_dump/spdm/spdm_dump_session.c
@@ -12,10 +12,6 @@ extern size_t m_local_used_cert_chain_buffer_size;
 extern void *m_peer_cert_chain_buffer;
 extern size_t m_peer_cert_chain_buffer_size;
 
-void *m_requester_cert_chain_buffer;
-size_t m_requester_cert_chain_buffer_size;
-void *m_responder_cert_chain_buffer;
-size_t m_responder_cert_chain_buffer_size;
 void *m_dhe_secret_buffer;
 size_t m_dhe_secret_buffer_size;
 void *m_psk_buffer;

--- a/spdm_dump/spdm_dump.c
+++ b/spdm_dump/spdm_dump.c
@@ -603,6 +603,9 @@ void process_args(int argc, char *argv[])
 
         if (strcmp(argv[0], "--req_cert_chain") == 0) {
             if (argc >= 2) {
+                if (m_requester_cert_chain_buffer != NULL) {
+                    free(m_requester_cert_chain_buffer);
+                }
                 res = read_input_file(
                     argv[1], &m_requester_cert_chain_buffer,
                     &m_requester_cert_chain_buffer_size);
@@ -629,6 +632,9 @@ void process_args(int argc, char *argv[])
 
         if (strcmp(argv[0], "--rsp_cert_chain") == 0) {
             if (argc >= 2) {
+                if (m_responder_cert_chain_buffer != NULL) {
+                    free(m_responder_cert_chain_buffer);
+                }
                 res = read_input_file(
                     argv[1], &m_responder_cert_chain_buffer,
                     &m_responder_cert_chain_buffer_size);

--- a/spdm_dump/spdm_dump.h
+++ b/spdm_dump/spdm_dump.h
@@ -129,10 +129,10 @@ extern bool m_param_dump_hex;
 extern char *m_param_out_rsp_cert_chain_file_name;
 extern char *m_param_out_rsq_cert_chain_file_name;
 
-extern void *m_requester_cert_chain_buffer;
-extern size_t m_requester_cert_chain_buffer_size;
-extern void *m_responder_cert_chain_buffer;
-extern size_t m_responder_cert_chain_buffer_size;
+void *m_requester_cert_chain_buffer = NULL;
+size_t m_requester_cert_chain_buffer_size;
+void *m_responder_cert_chain_buffer = NULL;
+size_t m_responder_cert_chain_buffer_size;
 extern void *m_dhe_secret_buffer;
 extern size_t m_dhe_secret_buffer_size;
 extern void *m_psk_buffer;


### PR DESCRIPTION
…ost.
Fix: #42 
Signed-off-by: Zhao, Zhiqiang <zhiqiang.zhao@intel.com>