### PR TITLE
Check 'm_responder_cert_chain_buffer' size

### DIFF
--- a/spdm_dump/spdm_dump.c
+++ b/spdm_dump/spdm_dump.c
@@ -12,6 +12,10 @@ bool m_param_dump_vendor_app;
 bool m_param_dump_hex;
 char *m_param_out_rsp_cert_chain_file_name;
 char *m_param_out_rsq_cert_chain_file_name;
+size_t m_requester_cert_chain_buffer_size;
+void *m_requester_cert_chain_buffer = NULL;
+size_t m_responder_cert_chain_buffer_size;
+void *m_responder_cert_chain_buffer = NULL;
 
 extern uint32_t m_spdm_requester_capabilities_flags;
 extern uint32_t m_spdm_responder_capabilities_flags;
@@ -643,7 +647,7 @@ void process_args(int argc, char *argv[])
                     print_usage();
                     exit(0);
                 }
-                if (m_requester_cert_chain_buffer_size >
+                if (m_responder_cert_chain_buffer_size >
                     LIBSPDM_MAX_CERT_CHAIN_SIZE) {
                     printf(
                         "rsp_cert_chain is too larger. Please increase LIBSPDM_MAX_CERT_CHAIN_SIZE and rebuild.\n");

--- a/spdm_dump/spdm_dump.h
+++ b/spdm_dump/spdm_dump.h
@@ -129,10 +129,10 @@ extern bool m_param_dump_hex;
 extern char *m_param_out_rsp_cert_chain_file_name;
 extern char *m_param_out_rsq_cert_chain_file_name;
 
-void *m_requester_cert_chain_buffer = NULL;
-size_t m_requester_cert_chain_buffer_size;
-void *m_responder_cert_chain_buffer = NULL;
-size_t m_responder_cert_chain_buffer_size;
+extern void *m_requester_cert_chain_buffer;
+extern size_t m_requester_cert_chain_buffer_size;
+extern void *m_responder_cert_chain_buffer;
+extern size_t m_responder_cert_chain_buffer_size;
 extern void *m_dhe_secret_buffer;
 extern size_t m_dhe_secret_buffer_size;
 extern void *m_psk_buffer;


### PR DESCRIPTION
Replace `m_requester_cert_chain_buffer_size` with `m_responder_cert_chain_buffer_size`

Redefine `m_requester_cert_chain_buffer` and `m_requester_cert_chain_buffer_size` and `m_responder_cert_chain_buffer` and `m_responder_cert_chain_buffer_size`

Fix: #45

Signed-off-by: yaohuixguo <yaohuix.guo@intel.com>