### PR TITLE
Add multi session support

### DIFF
--- a/doc/spdm_dump.md
+++ b/doc/spdm_dump.md
@@ -201,6 +201,8 @@ This document describes spdm_dump tool. It can be used to parse the SPDM message
 
 3. If GET_CERTIFICATE or encapsulated GET_CERTIFICATE is not sent (e.g. when SlotId 0xFF is used or PUB_KEY_ID is used), the user need use `--rsp_cert_chain` or `--req_cert_chain` to indicate the responder certificate chain or the requester certificate chain, to dump the secured session data.
 
+   Note: If the user need input multi `--rsp_cert_chain` or  `--req_cert_chain`, the cert_chain need be inputed in order for slot_id. And max of the cert_chain number is SPDM_MAX_SLOT_COUNT.
+
    For example, `spdm_dump -r SpdmRequester.pcap --psk 5465737450736b4461746100 --dhe_secret c7ac17ee29b6a4f84e978223040b7eddff792477a6f7fc0f51faa553fee58175 --req_cert_chain rsa3072/bundle_requester.certchain.der --rsp_cert_chain ecp384/bundle_responder.certchain.der`
 
    If GET_CERTIFICATE or encapsulated GET_CERTIFICATE is sent, the user may use `--out_rsp_cert_chain` or `--out_req_cert_chain` to get the responder certificate chain or the requester certificate chain.

--- a/doc/spdm_dump.md
+++ b/doc/spdm_dump.md
@@ -149,6 +149,9 @@ This document describes spdm_dump tool. It can be used to parse the SPDM message
 
    Then the user may use command `spdm_dump -r SpdmRequester.pcap --psk 5465737450736b4461746100 --dhe_secret c7ac17ee29b6a4f84e978223040b7eddff792477a6f7fc0f51faa553fee58175`
 
+   Note: If there are multi session which need multi key, please input the key in order of session. For example, there are four session: session1 used dhe_key1; session2 used psk_key1; session3 used dhe_key2; session4 used psk_key2.
+   Then the user may use command `spdm_dump -r SpdmRequester.pcap --psk psk_key1 --psk psk_key2 --dhe_secret dhe_key1 --dhe_secret dhe_key2`
+
    A full SPDM log is like below:
 
    <pre>

--- a/spdm_dump/spdm/spdm_dump_session.c
+++ b/spdm_dump/spdm/spdm_dump_session.c
@@ -16,7 +16,8 @@ void *m_dhe_secret_buffer;
 size_t m_dhe_secret_buffer_size;
 void *m_psk_buffer;
 size_t m_psk_buffer_size;
-uint8_t m_use_slot_id = 0;
+uint8_t m_responder_cert_chain_slot_id = 0;
+uint8_t m_requester_cert_chain_slot_id = 0;
 
 libspdm_return_t spdm_dump_session_data_provision(void *spdm_context,
                                                uint32_t session_id,
@@ -65,15 +66,15 @@ libspdm_return_t spdm_dump_session_data_provision(void *spdm_context,
 
         if (is_requester) {
             if (need_mut_auth && mut_auth_requested) {
-                if (m_requester_cert_chain_buffer == NULL ||
-                    m_requester_cert_chain_buffer_size == 0) {
+                if (m_requester_cert_chain_buffer[m_requester_cert_chain_slot_id] == NULL ||
+                    m_requester_cert_chain_buffer_size[m_requester_cert_chain_slot_id] == 0) {
                     return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
                 }
                 memcpy((uint8_t *)m_local_used_cert_chain_buffer,
-                       m_requester_cert_chain_buffer,
-                       m_requester_cert_chain_buffer_size);
+                       m_requester_cert_chain_buffer[m_requester_cert_chain_slot_id],
+                       m_requester_cert_chain_buffer_size[m_requester_cert_chain_slot_id]);
                 m_local_used_cert_chain_buffer_size =
-                    m_requester_cert_chain_buffer_size;
+                    m_requester_cert_chain_buffer_size[m_requester_cert_chain_slot_id];
                 libspdm_zero_mem(&parameter, sizeof(parameter));
                 parameter.location =
                     LIBSPDM_DATA_LOCATION_CONNECTION;
@@ -84,32 +85,32 @@ libspdm_return_t spdm_dump_session_data_provision(void *spdm_context,
                     m_local_used_cert_chain_buffer,
                     m_local_used_cert_chain_buffer_size);
             }
-            if (m_responder_cert_chain_buffer == NULL ||
-                m_responder_cert_chain_buffer_size == 0) {
+            if (m_responder_cert_chain_buffer[m_responder_cert_chain_slot_id] == NULL ||
+                m_responder_cert_chain_buffer_size[m_responder_cert_chain_slot_id] == 0) {
                 return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
             }
             memcpy((uint8_t *)m_peer_cert_chain_buffer,
-                   m_responder_cert_chain_buffer,
-                   m_responder_cert_chain_buffer_size);
+                   m_responder_cert_chain_buffer[m_responder_cert_chain_slot_id],
+                   m_responder_cert_chain_buffer_size[m_responder_cert_chain_slot_id]);
             m_peer_cert_chain_buffer_size =
-                m_responder_cert_chain_buffer_size;
+                m_responder_cert_chain_buffer_size[m_responder_cert_chain_slot_id];
             libspdm_zero_mem(&parameter, sizeof(parameter));
-            parameter.additional_data[0] = m_use_slot_id;
+            parameter.additional_data[0] = m_responder_cert_chain_slot_id;
             parameter.location = LIBSPDM_DATA_LOCATION_CONNECTION;
             libspdm_set_data(spdm_context,
                              LIBSPDM_DATA_PEER_USED_CERT_CHAIN_BUFFER,
                              &parameter, m_peer_cert_chain_buffer,
                              m_peer_cert_chain_buffer_size);
         } else {
-            if (m_responder_cert_chain_buffer == NULL ||
-                m_responder_cert_chain_buffer_size == 0) {
+            if (m_responder_cert_chain_buffer[m_responder_cert_chain_slot_id] == NULL ||
+                m_responder_cert_chain_buffer_size[m_responder_cert_chain_slot_id] == 0) {
                 return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
             }
             memcpy((uint8_t *)m_local_used_cert_chain_buffer,
-                   m_responder_cert_chain_buffer,
-                   m_responder_cert_chain_buffer_size);
+                   m_responder_cert_chain_buffer[m_responder_cert_chain_slot_id],
+                   m_responder_cert_chain_buffer_size[m_responder_cert_chain_slot_id]);
             m_local_used_cert_chain_buffer_size =
-                m_responder_cert_chain_buffer_size;
+                m_responder_cert_chain_buffer_size[m_responder_cert_chain_slot_id];
             libspdm_zero_mem(&parameter, sizeof(parameter));
             parameter.location = LIBSPDM_DATA_LOCATION_CONNECTION;
             libspdm_set_data(spdm_context,
@@ -118,19 +119,19 @@ libspdm_return_t spdm_dump_session_data_provision(void *spdm_context,
                              m_local_used_cert_chain_buffer,
                              m_local_used_cert_chain_buffer_size);
             if (need_mut_auth && mut_auth_requested) {
-                if (m_requester_cert_chain_buffer == NULL ||
-                    m_requester_cert_chain_buffer_size == 0) {
+                if (m_requester_cert_chain_buffer[m_requester_cert_chain_slot_id] == NULL ||
+                    m_requester_cert_chain_buffer_size[m_requester_cert_chain_slot_id] == 0) {
                     return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
                 }
                 memcpy((uint8_t *)m_peer_cert_chain_buffer,
-                       m_requester_cert_chain_buffer,
-                       m_requester_cert_chain_buffer_size);
+                       m_requester_cert_chain_buffer[m_requester_cert_chain_slot_id],
+                       m_requester_cert_chain_buffer_size[m_requester_cert_chain_slot_id]);
                 m_peer_cert_chain_buffer_size =
-                    m_requester_cert_chain_buffer_size;
+                    m_requester_cert_chain_buffer_size[m_requester_cert_chain_slot_id];
                 libspdm_zero_mem(&parameter, sizeof(parameter));
                 parameter.location =
                     LIBSPDM_DATA_LOCATION_CONNECTION;
-                parameter.additional_data[0] = m_use_slot_id;
+                parameter.additional_data[0] = m_requester_cert_chain_slot_id;
                 libspdm_set_data(
                     spdm_context,
                     LIBSPDM_DATA_PEER_USED_CERT_CHAIN_BUFFER,
@@ -188,23 +189,23 @@ libspdm_return_t spdm_dump_session_data_check(void *spdm_context,
         }
         if (is_requester) {
             if (mut_auth_requested) {
-                if (m_requester_cert_chain_buffer == NULL ||
-                    m_requester_cert_chain_buffer_size == 0) {
+                if (m_requester_cert_chain_buffer[m_requester_cert_chain_slot_id] == NULL ||
+                    m_requester_cert_chain_buffer_size[m_requester_cert_chain_slot_id] == 0) {
                     return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
                 }
             }
-            if (m_responder_cert_chain_buffer == NULL ||
-                m_responder_cert_chain_buffer_size == 0) {
+            if (m_responder_cert_chain_buffer[m_responder_cert_chain_slot_id] == NULL ||
+                m_responder_cert_chain_buffer_size[m_responder_cert_chain_slot_id] == 0) {
                 return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
             }
         } else {
-            if (m_responder_cert_chain_buffer == NULL ||
-                m_responder_cert_chain_buffer_size == 0) {
+            if (m_responder_cert_chain_buffer[m_responder_cert_chain_slot_id] == NULL ||
+                m_responder_cert_chain_buffer_size[m_responder_cert_chain_slot_id] == 0) {
                 return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
             }
             if (mut_auth_requested) {
-                if (m_requester_cert_chain_buffer == NULL ||
-                    m_requester_cert_chain_buffer_size == 0) {
+                if (m_requester_cert_chain_buffer[m_requester_cert_chain_slot_id] == NULL ||
+                    m_requester_cert_chain_buffer_size[m_requester_cert_chain_slot_id] == 0) {
                     return LIBSPDM_STATUS_INVALID_STATE_LOCAL;
                 }
             }

--- a/spdm_dump/spdm_dump.c
+++ b/spdm_dump/spdm_dump.c
@@ -256,6 +256,13 @@ void process_args(int argc, char *argv[])
     uint8_t req_slot_id_index;
     rsp_slot_id_index = 0;
     req_slot_id_index = 0;
+
+    /*key params input time*/
+    uint8_t psk_key_input_count;
+    uint8_t dhe_key_input_count;
+    psk_key_input_count = 0;
+    dhe_key_input_count = 0;
+
     pcap_file_name = NULL;
 
     if (argc == 1) {
@@ -316,15 +323,22 @@ void process_args(int argc, char *argv[])
 
         if (strcmp(argv[0], "--psk") == 0) {
             if (argc >= 2) {
+                if (psk_key_input_count >= LIBSPDM_MAX_SESSION_COUNT) {
+                    printf("too many psk key input \n");
+                    print_usage();
+                    exit(0);
+                }
                 if (!hex_string_to_buffer(argv[1],
-                                          &m_psk_buffer,
-                                          &m_psk_buffer_size)) {
+                                          &m_psk_buffer[psk_key_input_count],
+                                          &m_psk_buffer_size[psk_key_input_count])) {
                     printf("invalid --psk\n");
                     print_usage();
                     exit(0);
                 }
                 argc -= 2;
                 argv += 2;
+
+                psk_key_input_count++;
                 continue;
             } else {
                 printf("invalid --psk\n");
@@ -335,15 +349,22 @@ void process_args(int argc, char *argv[])
 
         if (strcmp(argv[0], "--dhe_secret") == 0) {
             if (argc >= 2) {
+                if (dhe_key_input_count >= LIBSPDM_MAX_SESSION_COUNT) {
+                    printf("too many dhe key input \n");
+                    print_usage();
+                    exit(0);
+                }
                 if (!hex_string_to_buffer(
-                        argv[1], &m_dhe_secret_buffer,
-                        &m_dhe_secret_buffer_size)) {
+                        argv[1], &m_dhe_secret_buffer[dhe_key_input_count],
+                        &m_dhe_secret_buffer_size[dhe_key_input_count])) {
                     printf("invalid --dhe_secret\n");
                     print_usage();
                     exit(0);
                 }
                 argc -= 2;
                 argv += 2;
+
+                dhe_key_input_count++;
                 continue;
             } else {
                 printf("invalid --dhe_secret\n");

--- a/spdm_dump/spdm_dump.h
+++ b/spdm_dump/spdm_dump.h
@@ -139,13 +139,15 @@ extern bool m_param_dump_hex;
 extern char *m_param_out_rsp_cert_chain_file_name;
 extern char *m_param_out_rsq_cert_chain_file_name;
 
-extern void *m_requester_cert_chain_buffer;
-extern size_t m_requester_cert_chain_buffer_size;
-extern void *m_responder_cert_chain_buffer;
-extern size_t m_responder_cert_chain_buffer_size;
+extern void *m_requester_cert_chain_buffer[SPDM_MAX_SLOT_COUNT];
+extern size_t m_requester_cert_chain_buffer_size[SPDM_MAX_SLOT_COUNT];
+extern void *m_responder_cert_chain_buffer[SPDM_MAX_SLOT_COUNT];
+extern size_t m_responder_cert_chain_buffer_size[SPDM_MAX_SLOT_COUNT];
 extern void *m_dhe_secret_buffer;
 extern size_t m_dhe_secret_buffer_size;
 extern void *m_psk_buffer;
 extern size_t m_psk_buffer_size;
 
+extern uint8_t m_responder_cert_chain_slot_id;
+extern uint8_t m_requester_cert_chain_slot_id;
 #endif

--- a/spdm_dump/spdm_dump.h
+++ b/spdm_dump/spdm_dump.h
@@ -143,10 +143,14 @@ extern void *m_requester_cert_chain_buffer[SPDM_MAX_SLOT_COUNT];
 extern size_t m_requester_cert_chain_buffer_size[SPDM_MAX_SLOT_COUNT];
 extern void *m_responder_cert_chain_buffer[SPDM_MAX_SLOT_COUNT];
 extern size_t m_responder_cert_chain_buffer_size[SPDM_MAX_SLOT_COUNT];
-extern void *m_dhe_secret_buffer;
-extern size_t m_dhe_secret_buffer_size;
-extern void *m_psk_buffer;
-extern size_t m_psk_buffer_size;
+extern void *m_dhe_secret_buffer[LIBSPDM_MAX_SESSION_COUNT];
+extern size_t m_dhe_secret_buffer_size[LIBSPDM_MAX_SESSION_COUNT];
+extern void *m_psk_buffer[LIBSPDM_MAX_SESSION_COUNT];
+extern size_t m_psk_buffer_size[LIBSPDM_MAX_SESSION_COUNT];
+
+/*current used key index, index++ when finish command dump complete*/
+extern uint8_t m_dhe_secret_buffer_count;
+extern uint8_t m_psk_secret_buffer_count;
 
 extern uint8_t m_responder_cert_chain_slot_id;
 extern uint8_t m_requester_cert_chain_slot_id;


### PR DESCRIPTION
Fix: #35 

Change cert_chain_buffer to array to store 0-7 slot_id cert_chain;
Add multi session support by inputting multi session key;


The follow test has passed:
![image](https://user-images.githubusercontent.com/87060980/190960969-72e96214-b72f-4e8f-bd3b-20e420898d62.png)




Signed-off-by: Wenxing Hou <wenxing.hou@intel.com>